### PR TITLE
fix: corregir errores de tests y aislamiento de estado en disco

### DIFF
--- a/core/capital_repository.py
+++ b/core/capital_repository.py
@@ -11,6 +11,8 @@ from core.utils.logger import configurar_logger
 
 log = configurar_logger("capital_repository", modo_silencioso=True)
 
+RUTA_CAPITAL = Path("estado/capital.json")
+
 
 @dataclass(slots=True)
 class CapitalSnapshot:
@@ -24,7 +26,7 @@ class CapitalRepository:
     """Persistencia en disco usando un archivo JSON con escritura atómica."""
 
     def __init__(self, path: str | Path | None = None) -> None:
-        base_path = Path(path) if path is not None else Path("estado/capital.json")
+        base_path = Path(path) if path is not None else RUTA_CAPITAL
         self.path = base_path.expanduser().resolve()
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()

--- a/learning/config_output_path.py
+++ b/learning/config_output_path.py
@@ -12,15 +12,19 @@ _TMP_ROOT = Path(tempfile.gettempdir()).resolve()
 
 
 def _pytest_temp_path_ok(resolved: Path) -> bool:
-    """Permite ``tmp_path`` bajo el directorio temporal del SO solo durante pytest."""
+    """Permite ``tmp_path`` (basetemp ``pytest-*``) solo durante pytest.
+
+    Restringido al árbol que crea el fixture ``tmp_path`` para que otras rutas
+    bajo el directorio temporal del SO sigan rechazándose incluso en tests.
+    """
 
     if not os.environ.get("PYTEST_CURRENT_TEST"):
         return False
     try:
-        resolved.relative_to(_TMP_ROOT)
+        rel = resolved.relative_to(_TMP_ROOT)
     except ValueError:
         return False
-    return True
+    return bool(rel.parts) and rel.parts[0].startswith("pytest-")
 
 
 def resolve_repo_input_path(path: Path) -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,50 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture(autouse=True)
+def aislar_estado_en_disco(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirige a ``tmp_path`` los ficheros de estado que el flujo de cierre
+    de órdenes y los guards de riesgo escriben con rutas relativas al repo.
+
+    Sin esto, la suite muta ``estado/capital.json``, ``config/riesgo.json``,
+    ``estado/umbral_adaptativo.json`` y crea ``estado/per_symbol_losses.json``
+    reales (observado vía ``git status`` tras ejecutar la suite).
+    """
+    import core.adaptador_umbral as adaptador_umbral
+    import core.capital_repository as capital_repository
+    import core.orders.orphan_reconciler as orphan_reconciler
+    import core.risk.per_symbol_guard as per_symbol_guard
+    import core.risk.riesgo as riesgo
+
+    # El Event singleton de ccxt-ready queda ligado al loop del primer test
+    # que lo crea; tests posteriores (loop nuevo) reciben RuntimeError
+    # "bound to a different event loop" al hacer wait(). Reset por test.
+    monkeypatch.setattr(orphan_reconciler, "_CCXT_READY", None)
+
+    monkeypatch.setattr(
+        capital_repository, "RUTA_CAPITAL", tmp_path / "capital.json"
+    )
+    monkeypatch.setattr(
+        per_symbol_guard, "_STATE_PATH", tmp_path / "per_symbol_losses.json"
+    )
+    monkeypatch.setattr(
+        adaptador_umbral, "RUTA_ESTADO", tmp_path / "umbral_adaptativo.json"
+    )
+    monkeypatch.setattr(riesgo, "RUTA_ESTADO", str(tmp_path / "riesgo.json"))
+    monkeypatch.setattr(
+        riesgo, "RUTA_ESTADO_BAK", str(tmp_path / "riesgo.json.bak")
+    )
+    monkeypatch.setattr(riesgo, "_LOCK_PATH", str(tmp_path / "riesgo.json.lock"))
+
+    yield
+
+    # El singleton AsyncRiskPersistence escribe desde un hilo con flush
+    # diferido (0.5 s): hay que drenarlo y destruirlo ANTES de que monkeypatch
+    # restaure las rutas reales, o el flush pendiente escribiría en el repo.
+    if riesgo._PERSISTENCIA is not None:
+        riesgo.detener_persistencia()
+
+
+@pytest.fixture(autouse=True)
 def stub_data_feed(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
     """Reemplaza ``DataFeed`` por un stub liviano durante los tests."""
 

--- a/tests/test_candle_processing_path.py
+++ b/tests/test_candle_processing_path.py
@@ -71,7 +71,7 @@ async def _run_consumer(
         pass
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_consume_y_procesa_una_vela_cerrada(
     trader_factory,
     datafeed_instance,
@@ -111,7 +111,7 @@ async def test_consume_y_procesa_una_vela_cerrada(
     assert spy.calls >= 1, "Trader._procesar_vela debe invocarse al menos una vez"
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_registra_hitos_de_evaluacion(
     trader_factory,
     datafeed_instance,
@@ -159,7 +159,7 @@ async def test_registra_hitos_de_evaluacion(
     assert not has_event(records, "datafeed", "consumer.skip", symbol="BTCUSDT")
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_no_marca_bar_in_future_con_timestamp_valido(
     trader_factory,
     datafeed_instance,
@@ -184,7 +184,7 @@ async def test_no_marca_bar_in_future_con_timestamp_valido(
     ), "No debe descartarse por bar_ts_out_of_range"
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_fastpath_registra_skip_reason_visible(
     trader_factory,
     datafeed_instance,
@@ -210,7 +210,7 @@ async def test_fastpath_registra_skip_reason_visible(
     )
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_no_pipeline_missing_con_pipeline_configurado(
     trader_factory,
     datafeed_instance,
@@ -254,7 +254,7 @@ class _StrictMetric:
         return None
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_metricas_no_rompen_por_labels(
     trader_factory,
     datafeed_instance,
@@ -295,7 +295,7 @@ async def test_metricas_no_rompen_por_labels(
     "symbol",
     ["BTC/EUR", "ETH/EUR", "SOL/EUR", "ADA/EUR", "BNB/EUR"],
 )
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 async def test_procesa_multisimbolo_sin_skips(
     symbol: str,
     trader_factory,

--- a/tests/test_config_handler_timeout_default.py
+++ b/tests/test_config_handler_timeout_default.py
@@ -22,8 +22,12 @@ def test_development_default_symbols_are_binance_spot_usdt() -> None:
     assert DevelopmentConfig().symbols == ["BTC/USDT", "ETH/USDT"]
 
 
-def test_production_default_symbols_match_development_spot_usdt() -> None:
-    assert ProductionConfig().symbols == ["BTC/USDT", "ETH/USDT"]
+def test_production_default_symbols_are_documented_universe() -> None:
+    # Universo de producción según estudio_simbolos (ver config/production.py):
+    # BTC/ETH/SOL (PF test 1.48-3.97) + XRP/AVAX (reemplazan ADA y BNB).
+    assert ProductionConfig().symbols == [
+        "BTC/USDT", "ETH/USDT", "SOL/USDT", "XRP/USDT", "AVAX/USDT"
+    ]
 
 
 def test_config_manager_respects_symbols_env_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_e2e_bot_flow.py
+++ b/tests/test_e2e_bot_flow.py
@@ -162,7 +162,7 @@ class BotFlowHarness:
         return self._procesar_calls
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags(
     "orders.retry_persistencia.enabled",
     "orders.flush_periodico.enabled",
@@ -213,7 +213,7 @@ async def test_flow_happy_path_emits_attempts_and_metrics(trader_factory, caplog
     assert feed._stats[harness.symbol]["processed"] == len(candles)
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags("datafeed.debug_wrapper.enabled")
 async def test_flow_bar_in_future_skips_with_reason(trader_factory, caplog) -> None:
     _enable_flow_logging(caplog)
@@ -244,7 +244,7 @@ async def test_flow_bar_in_future_skips_with_reason(trader_factory, caplog) -> N
     assert last.get("details"), "Los skips deben incluir detalles diagnósticos"
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags("datafeed.debug_wrapper.enabled")
 async def test_flow_out_of_range_skips_with_reason(trader_factory, caplog) -> None:
     _enable_flow_logging(caplog)
@@ -272,7 +272,7 @@ async def test_flow_out_of_range_skips_with_reason(trader_factory, caplog) -> No
     assert skips[-1].get("event") == "consumer.skip"
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags("trader.purge_historial.enabled")
 async def test_flow_warmup_not_met_reports_reason(trader_factory, caplog) -> None:
     _enable_flow_logging(caplog)
@@ -301,7 +301,7 @@ async def test_flow_warmup_not_met_reports_reason(trader_factory, caplog) -> Non
     assert last.get("min_needed") == 4
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags("orders.retry_persistencia.enabled")
 async def test_flow_pipeline_missing_propagates_reason(trader_factory, caplog) -> None:
     _enable_flow_logging(caplog)
@@ -335,7 +335,7 @@ async def test_flow_pipeline_missing_propagates_reason(trader_factory, caplog) -
         assert isinstance(details.get("pipeline_error_message"), str)
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags("orders.retry_persistencia.enabled")
 async def test_flow_pipeline_missing_exposes_component_error(trader_factory, caplog) -> None:
     _enable_flow_logging(caplog)
@@ -361,7 +361,7 @@ async def test_flow_pipeline_missing_exposes_component_error(trader_factory, cap
     assert "pipeline exploded" in details.get("pipeline_error_message", "")
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags("metrics.extended.enabled")
 async def test_flow_fastpath_guard_emits_metric(trader_factory, caplog) -> None:
     _enable_flow_logging(caplog)
@@ -395,7 +395,7 @@ async def test_flow_fastpath_guard_emits_metric(trader_factory, caplog) -> None:
         assert details.get("resume_threshold") == trader.config.trader_fastpath_resume_threshold
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags(
     "datafeed.debug_wrapper.enabled",
     "backfill.ventana.enabled",
@@ -421,7 +421,7 @@ async def test_flow_backpressure_does_not_block_attempt(trader_factory, caplog) 
     assert feed._stats[harness.symbol]["received"] == len(candles)
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags(
     "funding.enabled",
     "datafeed.debug_wrapper.enabled",

--- a/tests/test_integration_flujo_bot_completo.py
+++ b/tests/test_integration_flujo_bot_completo.py
@@ -33,7 +33,7 @@ def _clear_global_buffers() -> Iterable[None]:
     manager._locks.clear()
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags(
     "orders.retry_persistencia.enabled",
     "orders.flush_periodico.enabled",
@@ -85,7 +85,7 @@ async def test_flujo_integrado_multisimbolo_feed_trader_procesar_vela_ordenes(
         assert len(trader.estado[sym].buffer) == n_per
 
 
-@pytest.mark.asyncio(mode="strict")
+@pytest.mark.asyncio
 @pytest.mark.flags(
     "orders.retry_persistencia.enabled",
     "metrics.extended.enabled",


### PR DESCRIPTION
## Resumen

Auditoría de errores del bot guiada por evidencia (suite de tests + `git status` tras ejecutarla). Se encontraron y corrigieron 5 problemas:

### OBSERVADO (evidencia)
- 18 tests fallaban en **colección**: `ValueError: mark.asyncio accepts only keyword arguments 'loop_scope' and 'loop_factories'` (pytest-asyncio 1.4.0 ya no acepta `mode=`).
- 2 tests de seguridad de rutas no lanzaban `ValueError`: `resolve_config_output_path(Path("/tmp/evil_weights.json"))` pasaba sin error — la vía de escape de pytest permitía **cualquier** ruta bajo `/tmp`, anulando la validación anti path-traversal.
- 1 test de símbolos desactualizado: `ProductionConfig().symbols` tiene 5 símbolos documentados con backtesting (`config/production.py`), el test esperaba 2.
- Tras ejecutar la suite, `git status` mostraba mutaciones de ficheros **reales** del repo: `config/riesgo.json(.bak)` (fecha de hoy, pérdida 0.01 — proviene de `test_risk_manager_fixes.py:91`), `estado/capital.json` (clave `BTCUSDT` de `test_trader_logic.py`/`test_cooldown_crear_failed.py`), `estado/umbral_adaptativo.json`, y creación de `estado/per_symbol_losses.json` (`test_m07_finalizar_cierre.py`, `test_order_manager_quantity.py`).
- `RuntimeError: Event ... is bound to a different event loop` en task `wait_ccxt` tras la suite (singleton `_CCXT_READY` ligado al loop del primer test).

### Cambios
1. **tests**: eliminar `mode="strict"` del marker asyncio (3 ficheros, 18 tests).
2. **learning/config_output_path.py**: restringir la excepción de pytest al basetemp `pytest-*` del fixture `tmp_path` (la validación de rutas vuelve a rechazar el resto de `/tmp` incluso en tests).
3. **tests/test_config_handler_timeout_default.py**: alinear la aserción con el universo de producción documentado.
4. **tests/conftest.py**: fixture autouse que redirige a `tmp_path` las rutas de estado (`capital.json`, `riesgo.json`, `umbral_adaptativo.json`, `per_symbol_losses.json`), drena el hilo de `AsyncRiskPersistence` antes del teardown (su flush diferido de 0.5 s escribía en el repo con las rutas ya restauradas) y resetea `_CCXT_READY` por test.
5. **core/capital_repository.py**: ruta por defecto extraída a constante `RUTA_CAPITAL` (parcheable, mismo estilo que `riesgo.py`). Sin cambio de comportamiento.

### Verificación
- Suite completa: **934 passed, 3 skipped, 0 failed**.
- `git status` limpio tras ejecutar la suite (sin mutaciones de estado).
- `ruff --select F821,F811,E9`: sin errores.

https://claude.ai/code/session_01XGQtQnDjKFnCZYK4onZfSR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGQtQnDjKFnCZYK4onZfSR)_